### PR TITLE
Rename SocketModeMessageRouter to SocketModeRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **BREAKING**: Renamed `SocketModeMessageRouter` to `SocketModeRouter` for brevity and consistency
+  - Class renamed from `SocketModeMessageRouter` to `SocketModeRouter`
+  - Method renamed from `addSocketModeMessageRouter(_:)` to `addSocketModeRouter(_:)`
+  - All related type references updated accordingly
+
 ## [0.0.4] - 2025-06-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ case "message":
 
 ### Usage
 ```swift
-let router = SocketModeMessageRouter()
+let router = SocketModeRouter()
 
 router.onSlashCommand("/echo") { context, payload in
     try await context.client.chatPostMessage(
@@ -125,7 +125,7 @@ router.onEvent(AppMentionEvent.self) { context, envelope, event in
     // Handle app mentions
 }
 
-await slack.addSocketModeMessageRouter(router)
+await slack.addSocketModeRouter(router)
 try await slack.runInSocketMode()
 ```
 

--- a/Examples/Sources/dsl/Command.swift
+++ b/Examples/Sources/dsl/Command.swift
@@ -21,7 +21,7 @@ struct Command {
             ),
         )
 
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         // Handle global shortcuts
         router.onGlboalShortcut("run-something") {
@@ -323,7 +323,7 @@ struct Command {
             print("Advanced modal opened: \(response)")
         }
 
-        await slack.addSocketModeMessageRouter(router)
+        await slack.addSocketModeRouter(router)
 
         // This is demo so this doesn't automatically reconnect to socket when disconnected
         print("Starting Socket Mode connection...")

--- a/Examples/Sources/echoSlashCommand/Command.swift
+++ b/Examples/Sources/echoSlashCommand/Command.swift
@@ -24,7 +24,7 @@ struct EchoSlashCommand {
             ),
         )
 
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onSlashCommand("/echo") { context, payload in
             // `respond` uses response_url
@@ -51,7 +51,7 @@ struct EchoSlashCommand {
             try await context.respond(to: payload.responseUrl, text: payload.text, responseType: .ephemeral)
         }
 
-        await slack.addSocketModeMessageRouter(router)
+        await slack.addSocketModeRouter(router)
         try await slack.runInSocketMode()
     }
 }

--- a/Examples/Sources/router/Command.swift
+++ b/Examples/Sources/router/Command.swift
@@ -21,7 +21,7 @@ struct Command {
             ),
         )
 
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onSocketModeMessage { _, _ in
             print("onMessage")
@@ -71,7 +71,7 @@ struct Command {
             print("onSlackMessageMatched: \(payload.text!)")
         }
 
-        await slack.addSocketModeMessageRouter(router)
+        await slack.addSocketModeRouter(router)
 
         try await slack.runInSocketMode()
     }

--- a/Examples/Sources/threadExpander/Command.swift
+++ b/Examples/Sources/threadExpander/Command.swift
@@ -29,7 +29,7 @@ struct ThreadExpander {
             .replacingOccurrences(of: "https://", with: "")
             .replacingOccurrences(of: ".slack.com/", with: "")
 
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onEvent(MessageEvent.self) { context, _, messageEvent in
             guard let threadTs = messageEvent.threadTs,
@@ -49,7 +49,7 @@ struct ThreadExpander {
             )
         }
 
-        await slack.addSocketModeMessageRouter(router)
+        await slack.addSocketModeRouter(router)
 
         print("🧵 Thread Expander started. Press Ctrl+C to stop.")
         try await slack.runInSocketMode()

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ print(try response.ok.body.json.ok)
 
 ### Socket Mode
 
-For Socket Mode, use `SocketModeMessageRouter` to register callbacks and
+For Socket Mode, use `SocketModeRouter` to register callbacks and
 route events, slash commands, global shortcuts, message shortcuts, and more.
 
 ```swift
@@ -136,7 +136,7 @@ let slack = Slack(
 )
 
 // Create a router
-let router = SocketModeMessageRouter()
+let router = SocketModeRouter()
 
 // onSocketModeMessage handles routing for all events
 //
@@ -208,7 +208,7 @@ router.onError { context, envelope, error in
     print("\(error)")
 }
 
-await slack.addSocketModeMessageRouter(router)
+await slack.addSocketModeRouter(router)
 
 try await slack.runInSocketMode()
 ```

--- a/Sources/SlackClient/Slack.swift
+++ b/Sources/SlackClient/Slack.swift
@@ -38,7 +38,7 @@ public actor Slack {
 
     #if SocketMode
     var socketModeState: SocketModeState = .notReady
-    var routers: [SocketModeMessageRouter.FixedRouter] = []
+    var routers: [SocketModeRouter.FixedRouter] = []
 
     let jsonEncoder = JSONEncoder()
     let jsonDecoder = JSONDecoder()

--- a/Sources/SlackClient/SocketMode/Slack+SocketMode.swift
+++ b/Sources/SlackClient/SocketMode/Slack+SocketMode.swift
@@ -32,8 +32,8 @@ extension Slack {
         }
     }
 
-    public func addSocketModeMessageRouter(_ router: SocketModeMessageRouter) {
-        routers.append(SocketModeMessageRouter.FixedRouter(from: router))
+    public func addSocketModeRouter(_ router: SocketModeRouter) {
+        routers.append(SocketModeRouter.FixedRouter(from: router))
     }
 
     func openConnection() async throws -> String {
@@ -47,7 +47,7 @@ extension Slack {
     }
 
     func doStartSocketMode(with url: String, options: SocketModeOptions, appLogger: Logger?) async throws {
-        let routerContext = SocketModeMessageRouter.Context(
+        let routerContext = SocketModeRouter.Context(
             client: client,
             logger: appLogger ?? logger,
             respond: Respond(transport: transport, logger: logger),

--- a/Sources/SlackClient/SocketMode/SocketModeOptions.swift
+++ b/Sources/SlackClient/SocketMode/SocketModeOptions.swift
@@ -4,7 +4,7 @@ public struct SocketModeOptions: OptionSet, RawRepresentable, Sendable {
 
     /// If enabled, `Slack.runInSocketMode` will not propagte app-level error to call-site
     /// and continue waiting for next message automatically. You can still handle the error
-    /// with ``SocketModeMessageRouter.onError`` but the error will be thrown unless opt-out this.
+    /// with ``SocketModeRouter.onError`` but the error will be thrown unless opt-out this.
     ///
     /// Any errors occured at lower-layer like following categories are not impacted with this and un-handled.
     ///

--- a/Sources/SlackClient/SocketMode/SocketModeRouter.swift
+++ b/Sources/SlackClient/SocketMode/SocketModeRouter.swift
@@ -2,15 +2,15 @@
 import Foundation
 import Logging
 
-public typealias SocketModeMessageHandler = @Sendable (SocketModeMessageRouter.Context, SocketModeMessageEnvelope) async throws -> Void
+public typealias SocketModeMessageHandler = @Sendable (SocketModeRouter.Context, SocketModeMessageEnvelope) async throws -> Void
 public typealias SocketModeMessagePayloadHandler<Payload: Sendable> =
-    @Sendable (SocketModeMessageRouter.Context, Payload) async throws -> Void
+    @Sendable (SocketModeRouter.Context, Payload) async throws -> Void
 public typealias SocketModeMessageEnvelopePayloadHandler<Envelope: Sendable, Payload: Sendable> =
-    @Sendable (SocketModeMessageRouter.Context, Envelope, Payload) async throws -> Void
+    @Sendable (SocketModeRouter.Context, Envelope, Payload) async throws -> Void
 public typealias SocketModeErrorHandler =
-    @Sendable (SocketModeMessageRouter.Context, SocketModeMessageEnvelope, Swift.Error) async throws -> Void
+    @Sendable (SocketModeRouter.Context, SocketModeMessageEnvelope, Swift.Error) async throws -> Void
 
-public final class SocketModeMessageRouter {
+public final class SocketModeRouter {
     public struct Context: Sendable {
         public let client: APIProtocol
         public let logger: Logger
@@ -27,12 +27,12 @@ public final class SocketModeMessageRouter {
         private let handlers: [SocketModeMessageHandler]
         private let errorHandler: SocketModeErrorHandler?
 
-        init(from router: SocketModeMessageRouter) {
+        init(from router: SocketModeRouter) {
             handlers = router.handlers
             errorHandler = router.errorHandler
         }
 
-        func dispatch(context: SocketModeMessageRouter.Context, messageEnvelope: SocketModeMessageEnvelope) async throws {
+        func dispatch(context: SocketModeRouter.Context, messageEnvelope: SocketModeMessageEnvelope) async throws {
             try await withThrowingDiscardingTaskGroup { group in
                 for handler in handlers {
                     group.addTask {

--- a/Tests/SlackClientTests/SocketModeRouterTests.swift
+++ b/Tests/SlackClientTests/SocketModeRouterTests.swift
@@ -7,12 +7,12 @@ import Testing
 import OpenAPIRuntime
 import HTTPTypes
 
-// Test the core functionality of SocketModeMessageRouter without requiring full mocking
+// Test the core functionality of SocketModeRouter without requiring full mocking
 // These tests verify that handlers are registered correctly and filtering logic works
 
-struct SocketModeMessageRouterTests {
+struct SocketModeRouterTests {
     @Test func onSocketModeMessageRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onSocketModeMessage { _, _ in
             // Handler body
@@ -23,7 +23,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onInteractiveRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onInteractive { _, _ in
             // Handler body
@@ -33,7 +33,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onGlobalShortcutRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onGlboalShortcut("test_shortcut") { _, _ in
             // Handler body
@@ -43,7 +43,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onMessageShortcutRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onMessageShortcut("test_message_shortcut") { _, _ in
             // Handler body
@@ -53,7 +53,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onSlashCommandRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onSlashCommand("/test") { _, _ in
             // Handler body
@@ -63,7 +63,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onSlashCommandRequiresSlashPrefix() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         // This should trigger a precondition failure since "test" doesn't start with "/"
         // In tests, precondition failures are hard to catch, so we'll test the valid case
@@ -78,7 +78,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onBlockActionRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onBlockAction("test_block_action") { _, _ in
             // Handler body
@@ -88,7 +88,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onViewRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onView("test_view") { _, _ in
             // Handler body
@@ -98,7 +98,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onViewSubmissionRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onViewSubmission("test_view_submission") { _, _ in
             // Handler body
@@ -108,7 +108,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onViewClosedRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onViewClosed("test_view_closed") { _, _ in
             // Handler body
@@ -118,7 +118,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onEventRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onEvent { _, _ in
             // Handler body
@@ -128,7 +128,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onSpecificEventRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onEvent(MessageEvent.self) { _, _, _ in
             // Handler body
@@ -138,7 +138,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onSlackMessageMatchedRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onSlackMessageMatched(with: "hello", "world") { _, _, _ in
             // Handler body
@@ -148,7 +148,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func onErrorRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onError { _, _, _ in
             // Handler body
@@ -160,7 +160,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func multipleHandlerRegistration() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         router.onSocketModeMessage { _, _ in
             // Handler 1
@@ -178,7 +178,7 @@ struct SocketModeMessageRouterTests {
     }
 
     @Test func slashCommandValidation() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
 
         // Valid slash command
         router.onSlashCommand("/valid") { _, _ in
@@ -322,7 +322,7 @@ struct SocketModeMessageRouterTests {
     // REGRESSION TEST: Verify that the onEvent method with specific event types compiles correctly
     // This test would fail to compile if commit 7882fc2 is reverted due to type parameter conflicts
     @Test func onEventTypeParameterRegression() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
         
         // This specific usage pattern would fail to compile with the original bug
         // because the type parameter T would conflict with the Event enum type
@@ -346,7 +346,7 @@ struct SocketModeMessageRouterTests {
     // REGRESSION TEST: Actual dispatch test that would fail if commit 7882fc2 is reverted
     // This test verifies that events are properly cast and handlers are actually executed
     @Test func onEventActualDispatchRegression() async throws {
-        let router = SocketModeMessageRouter()
+        let router = SocketModeRouter()
         
         // Use actor to safely track handler execution in concurrent context
         actor HandlerTracker {
@@ -455,7 +455,7 @@ struct SocketModeMessageRouterTests {
         // Create context with actual Slack instance for simplicity
         let slack = Slack(transport: transport)
         let client = await slack.client
-        let mockContext = SocketModeMessageRouter.Context(
+        let mockContext = SocketModeRouter.Context(
             client: client,
             logger: logger,
             respond: Respond(transport: transport, logger: logger),
@@ -463,7 +463,7 @@ struct SocketModeMessageRouterTests {
         )
         
         // Create FixedRouter and dispatch events
-        let fixedRouter = SocketModeMessageRouter.FixedRouter(from: router)
+        let fixedRouter = SocketModeRouter.FixedRouter(from: router)
         
         try await fixedRouter.dispatch(context: mockContext, messageEnvelope: messageSocketEnvelope)
         try await fixedRouter.dispatch(context: mockContext, messageEnvelope: appMentionSocketEnvelope)
@@ -484,7 +484,7 @@ struct SocketModeMessageRouterTests {
 }
 
 // Helper to access private properties for testing
-private extension SocketModeMessageRouter {
+private extension SocketModeRouter {
     var handlers: [SocketModeMessageHandler] {
         Mirror(reflecting: self).children.first(where: { $0.label == "handlers" })?.value as? [SocketModeMessageHandler] ?? []
     }


### PR DESCRIPTION
## Summary
- Renamed `SocketModeMessageRouter` to `SocketModeRouter` for brevity and consistency

## Changes
- Renamed the class from `SocketModeMessageRouter` to `SocketModeRouter`
- Renamed the method from `addSocketModeMessageRouter(_:)` to `addSocketModeRouter(_:)`
- Updated all references throughout the codebase including:
  - Source files
  - Test files
  - Documentation (README.md, CLAUDE.md)
  - All example code

## Breaking Change
This is a **breaking change** that will require users to update their code.

### Migration Guide
1. Replace all instances of `SocketModeMessageRouter` with `SocketModeRouter`
2. Replace calls to `addSocketModeMessageRouter(_:)` with `addSocketModeRouter(_:)`

#### Before:
```swift
let router = SocketModeMessageRouter()
await slack.addSocketModeMessageRouter(router)
```

#### After:
```swift
let router = SocketModeRouter()
await slack.addSocketModeRouter(router)
```

## Test plan
- [x] All existing tests pass
- [x] Examples compile correctly with the new naming
- [x] No references to old name remain in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)