### PR TITLE
Fix schema update workflow to only detect changes in Generated directories

### DIFF
--- a/.github/workflows/schema-update.yml
+++ b/.github/workflows/schema-update.yml
@@ -58,13 +58,17 @@ jobs:
           # Generate code
           make generate
 
-          # Check if there are any changes in generated source code (not just submodules)
-          if [[ -n $(git status --porcelain Sources/) ]]; then
+          # Check if there are any changes in generated source code (not just submodules or formatting)
+          # Only look for changes in Generated directories
+          GENERATED_CHANGES=$(git status --porcelain | grep -E "Sources/.*/Generated/.*\.swift$" || true)
+          
+          if [[ -n "$GENERATED_CHANGES" ]]; then
             echo "changes=true" >> $GITHUB_OUTPUT
-            echo "Generated code changes detected"
+            echo "Generated code changes detected:"
+            echo "$GENERATED_CHANGES"
           else
             echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No generated code changes - only submodule updates"
+            echo "No generated code changes - only submodule updates or formatting changes"
           fi
 
       - name: Run tests


### PR DESCRIPTION
## Summary
Fixed the schema update workflow to only create PRs when there are actual changes in generated code, not just formatting or other non-generated file changes.

## Problem
PR #15 was created by the schema update workflow with only formatting changes and no actual schema updates. This happened because the workflow was checking for any changes in the `Sources/` directory rather than specifically checking for changes in generated files.

## Solution
Updated the diff detection logic to only look for changes in `Sources/*/Generated/*.swift` files using:
```bash
GENERATED_CHANGES=$(git status --porcelain | grep -E "Sources/.*/Generated/.*\.swift$" || true)
```

This ensures that:
- PRs are only created when there are actual schema/API updates
- Formatting changes in non-generated files don't trigger PRs
- Submodule updates alone don't trigger PRs

## Test plan
The pattern was tested locally and correctly identifies generated files:
- `Sources/SlackModels/Generated/*.swift`
- `Sources/SlackClient/WebAPI/Generated/*.swift`
- `Sources/SlackClient/Events/Generated/*.swift`

🤖 Generated with [Claude Code](https://claude.ai/code)