### PR TITLE
Clean up DeepL demo dead code

### DIFF
--- a/DemoApps/deepl-translator/README.md
+++ b/DemoApps/deepl-translator/README.md
@@ -5,7 +5,7 @@ A Swift implementation of DeepL for Slack that enables users to translate messag
 ## Features
 
 - **Reaction Translation**: Add a flag emoji to any message to get it translated
-- **Global Shortcut**: Use `/deepl` or click the shortcut button to open a translation modal
+- **Global Shortcut**: Use the shortcut button to open a translation modal
 - **Message Shortcut**: Run a message action to translate the selected message and post the result in thread
 - **Thread Responses**: Translations are posted in message threads to keep channels organized
 - **Multiple Languages**: Supports 27+ languages with DeepL's translation API

--- a/DemoApps/deepl-translator/Sources/DeepLTranslator/App.swift
+++ b/DemoApps/deepl-translator/Sources/DeepLTranslator/App.swift
@@ -105,7 +105,7 @@ struct DeepLTranslatorApp {
                 return
             }
 
-            let loadingView = TranslationModal.buildLoadingView(lang: langValue, text: textValue)
+            let loadingView = TranslationModal.buildLoadingView()
             try await context.ack(responseAction: .update, view: loadingView)
 
             guard let translatedText = try await deepL.translate(text: textValue, targetLanguage: langValue) else {

--- a/DemoApps/deepl-translator/Sources/DeepLTranslator/DeepLClient.swift
+++ b/DemoApps/deepl-translator/Sources/DeepLTranslator/DeepLClient.swift
@@ -191,5 +191,4 @@ struct Translation: Codable {
 
 enum DeepLError: Error {
     case apiError(statusCode: Int)
-    case invalidResponse
 }

--- a/DemoApps/deepl-translator/Sources/DeepLTranslator/ReactionHandler.swift
+++ b/DemoApps/deepl-translator/Sources/DeepLTranslator/ReactionHandler.swift
@@ -54,7 +54,7 @@ public struct ReactionHandler: Sendable {
         }
         
         // Check if translation already posted in thread (use the same messages we just fetched)
-        if isAlreadyPosted(messages: messages, translatedText: translatedText) {
+        if isAlreadyPosted(messages: messages, originalMessageTs: originalMessage.ts, translatedText: translatedText) {
             return
         }
         
@@ -70,9 +70,13 @@ public struct ReactionHandler: Sendable {
         )
     }
     
-    private func isAlreadyPosted(messages: [Message], translatedText: String) -> Bool {
+    private func isAlreadyPosted(
+        messages: [Message],
+        originalMessageTs: String?,
+        translatedText: String
+    ) -> Bool {
         return messages.contains { message in
-            message.text == translatedText
+            message.ts != originalMessageTs && message.text == translatedText
         }
     }
 }

--- a/DemoApps/deepl-translator/Sources/DeepLTranslator/TranslationModal.swift
+++ b/DemoApps/deepl-translator/Sources/DeepLTranslator/TranslationModal.swift
@@ -12,7 +12,6 @@ public struct TranslationModal {
             var callbackId: String { "run-translation" }
             var title: TextObject { "DeepL API Runner :books:" }
             var submit: TextObject? { "Translate" }
-            var privateMetadata: String? { defaultLang }
             
             var blocks: [Block] {
                 Block.input(InputBlock(
@@ -27,7 +26,7 @@ public struct TranslationModal {
                 
                 Block.input(InputBlock(
                     label: TextObject(type: .plainText, text: "Language"),
-                    element: createLanguageSelect(defaultLang: defaultLang, options: languageOptions),
+                    element: createLanguageSelect(options: languageOptions),
                     blockId: "lang"
                 ))
             }
@@ -40,7 +39,11 @@ public struct TranslationModal {
                 }
             }
             
-            private func createLanguageSelect(defaultLang: String, options: [Option]) -> InputElementType {
+            private var initialLanguageOption: Option {
+                languageOptions.first { $0.render().value == defaultLang } ?? Option("English").value("en")
+            }
+
+            private func createLanguageSelect(options: [Option]) -> InputElementType {
                 return StaticSelect {
                     for option in options {
                         option
@@ -48,7 +51,7 @@ public struct TranslationModal {
                 }
                 .actionId("a")
                 .placeholder(Text("Select language"))
-                .initialOption(options.first ?? Option("English").value("en"))
+                .initialOption(initialLanguageOption)
                 .asInputElement()
             }
         }
@@ -62,11 +65,8 @@ public struct TranslationModal {
         }
     }
     
-    public static func buildLoadingView(lang: String, text: String) -> View {
+    public static func buildLoadingView() -> View {
         struct LoadingView: SlackModalView {
-            let lang: String
-            let text: String
-            
             var callbackId: String { "run-translation" }
             var title: TextObject { "DeepL API Runner :books:" }
             var close: TextObject? { "Close" }
@@ -79,7 +79,7 @@ public struct TranslationModal {
             }
         }
         
-        let view = LoadingView(lang: lang, text: text).render()
+        let view = LoadingView().render()
         switch view {
         case .modal(let modalView):
             return .modal(modalView)
@@ -94,11 +94,9 @@ public struct TranslationModal {
             let originalText: String
             let translatedText: String
             
-            var callbackId: String { "new-runner" }
             var title: TextObject { "DeepL API Runner :books:" }
             var close: TextObject? { "Close" }
             var submit: TextObject? { nil }
-            var privateMetadata: String? { lang }
             
             var blocks: [Block] {
                 Section {


### PR DESCRIPTION
## Summary
- remove unused DeepL demo modal metadata and dead error case
- make the translation modal honor the configured default language
- fix the DeepL demo README to describe the actual shortcut flow

## Verification
- cd DemoApps/deepl-translator && swift build