### PR TITLE
Fix type of the priority property in Channel.swift

### DIFF
--- a/Sources/SlackModels/Generated/Channel.swift
+++ b/Sources/SlackModels/Generated/Channel.swift
@@ -74,7 +74,7 @@ public struct Channel: Codable, Hashable, Sendable {
     /// - Remark: Generated from `#/components/schemas/Channel/previous_names`.
     public var previousNames: [Swift.String]?
     /// - Remark: Generated from `#/components/schemas/Channel/priority`.
-    public var priority: Swift.Int?
+    public var priority: Swift.Double?
     /// - Remark: Generated from `#/components/schemas/Channel/properties`.
     public var properties: Properties?
     /// - Remark: Generated from `#/components/schemas/Channel/purpose`.
@@ -163,7 +163,7 @@ public struct Channel: Codable, Hashable, Sendable {
         pendingConnectedTeamIds: [Swift.String]? = nil,
         pendingShared: [Swift.String]? = nil,
         previousNames: [Swift.String]? = nil,
-        priority: Swift.Int? = nil,
+        priority: Swift.Double? = nil,
         properties: Properties? = nil,
         purpose: Purpose? = nil,
         sharedTeamIds: [Swift.String]? = nil,

--- a/scripts/lib/visitors.rb
+++ b/scripts/lib/visitors.rb
@@ -211,6 +211,12 @@ class TypeFixer
               if data[key][prop_name].key?('$ref')
                 data[key][prop_name]['$ref'] = '#/components/schemas/WorkflowConfiguration'
               end
+            when /^priority$/
+              # Channel's priority is a float (eg. 0.123456789), but sample data in
+              # java-slack-sdk always shows it as 0, so quicktype infers integer.
+              if data[key][prop_name]['type'] == 'integer'
+                data[key][prop_name]['type'] = 'number'
+              end
             end
           end
         end


### PR DESCRIPTION
Priority should be a Double, not a Int.

I verified this by capturing the JSON data in the conversation list response; the partial json fragment of one of the channels is 

```
{
  "id": "G0TT63V7T",
  "created": 1458339823,
  "creator": "U0T85GML6",
  "is_org_shared": false,
  "is_im": false,
  "priority": 0.9974754463
}
```