### PR TITLE
Prepare 2026.7.0 CalVer release

### DIFF
--- a/.codex/skills/release-new-version/SKILL.md
+++ b/.codex/skills/release-new-version/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: release-new-version
-description: Prepare and publish a new swift-slack repository release when the user asks to bump a version, adopt or apply CalVer, update release files, update the changelog, create or move a git tag, push release refs, or create or edit a GitHub release. Use for release tasks that must happen through a PR and then from the latest synced `main` branch, with `YYYY.M.PATCH` version tags that do not use a `v` prefix.
+description: "Prepare and publish a new swift-slack repository release when the user asks to bump a version, adopt or apply CalVer, update release files, update the changelog, create or move a git tag, push release refs, or create or edit a GitHub release. Use for two-phase release work: prepare release metadata through a PR, then publish tags and GitHub releases only from the latest synced `main`, using `YYYY.M.PATCH` tags without a `v` prefix."
 ---
 
 # Release New Version
 
 ## Overview
 
-Use this skill to perform the full release flow safely: choose the CalVer version, update release-facing files, update `CHANGELOG.md`, commit release metadata through a PR, ensure the release commit is on the latest `main`, create or move the version tag, push the tag, and create or update the GitHub release page.
+Use this skill to perform the full release flow safely: choose the CalVer version, update release-facing files, update `CHANGELOG.md`, commit release metadata through a PR, then publish the tag and GitHub release only after the PR is merged into `main`.
 
-Treat `main` as the only valid source for release tags. Prepare release metadata on a branch and PR when files need to change. After the PR is merged, switch to `main`, sync it with `origin/main`, and publish the tag/release from that merged commit.
+Treat `main` as the only valid source for release tags. Prepare release metadata on a branch and PR when files need to change. After the PR is merged, switch to `main`, sync it with `origin/main`, and publish the tag/release from that merged commit. Do not run commands that create tags or GitHub releases from the release-preparation branch.
 
 ## Versioning
 
@@ -30,19 +30,23 @@ Treat `main` as the only valid source for release tags. Prepare release metadata
 
 ## Workflow
 
+Use two phases. Stop after Phase A unless the release metadata PR has already been merged or the user explicitly asks to publish an already-merged release.
+
+### Phase A: Prepare release metadata PR
+
 1. Verify repository state and choose a release branch.
    - Run `git status --short --branch`.
-   - Confirm the local base branch matches `origin/main`. If it does not, update from `origin/main` before changing release metadata.
+   - Confirm the local base branch starts from `origin/main`. If it does not, update from `origin/main` before changing release metadata.
    - Create or switch to a release preparation branch such as `codex/release-2026-7-0` unless the user explicitly asks only for local edits.
 2. Inspect release context.
    - Read the current `CHANGELOG.md`.
    - Inspect commits since the previous tag or release version so the changelog entry matches the actual release scope.
    - Check whether the target tag already exists locally or remotely.
    - Check whether a GitHub release for that tag already exists.
-3. Update release-facing files before tagging.
+3. Update release-facing files.
    - Convert the unreleased section into a dated release section, or add a new release section if the changelog format differs.
    - Keep the version string exact and never prepend `v`.
-   - Keep the changelog aligned with the commits that will actually be on the tagged `main` commit.
+   - Keep the changelog aligned with the commits expected to be on the tagged `main` commit.
    - Update README package dependency examples to the new release version.
    - Keep `AGENTS.md` and this skill aligned with the CalVer policy if the policy changes.
    - Keep `scripts/release.rb` validating `YYYY.M.PATCH` and suggesting the next monthly release counter.
@@ -53,19 +57,26 @@ Treat `main` as the only valid source for release tags. Prepare release metadata
 5. Commit the release metadata on the release preparation branch.
    - Create a dedicated commit such as `Prepare <version> release`.
    - Push the branch and open a PR. Do not push directly to `main`.
-6. After the PR merges, publish from `main`.
+
+### Phase B: Publish after merge
+
+6. Confirm the release metadata PR is merged.
+   - Do not publish if the release metadata is only on the preparation branch.
+   - If the user has not confirmed merge status, verify it with `git fetch origin` and the PR status before continuing.
+7. Publish from `main`.
    - Switch to `main`.
    - Fetch and fast-forward to `origin/main`.
    - Confirm the release metadata commit is present on `main`.
-   - Push `main` only when required by the release flow and permitted by branch protection; otherwise rely on the merged PR.
-7. Create or correct the tag.
+   - Do not create or push a new commit directly on `main`.
+8. Create or correct the tag.
    - Create an annotated tag named exactly `<version>`.
    - Never use a `v` prefix.
    - If the tag already exists on the wrong commit, move it only after the correct `main` commit exists, then force-push the tag update.
-8. Publish or correct the GitHub release.
+9. Publish or correct the GitHub release.
    - If no release exists, create it from the tag with notes sourced from the new changelog section.
    - If a release already exists, edit it so the notes and tag reference stay aligned with the corrected tag.
-9. Re-check final state.
+   - Inspect `scripts/release.rb` before using it. Use explicit `git` and `gh release` commands instead if the script's generated notes do not match the changelog-sourced release notes for this release.
+10. Re-check final state.
    - Confirm `HEAD`, `origin/main`, and `<version>^{}` resolve to the same commit.
    - Confirm the GitHub release URL and whether it is a draft or prerelease.
 
@@ -73,6 +84,8 @@ Treat `main` as the only valid source for release tags. Prepare release metadata
 
 - Do not publish release tags from feature branches, topic branches, or detached HEAD states.
 - Do not push release metadata directly to `main`; use a branch and PR.
+- Do not run `ruby scripts/release.rb <version> --yes` on the release-preparation branch because it creates and pushes the tag and GitHub release.
+- Do not use `scripts/release.rb` blindly; inspect it first because its release-note behavior may differ from the changelog-sourced notes required for the current release.
 - Do not tag before the changelog update is committed.
 - Do not use SemVer-style versions such as `0.12.0` for new releases.
 - Do not assume an existing release tag is correct; inspect it.
@@ -81,18 +94,22 @@ Treat `main` as the only valid source for release tags. Prepare release metadata
 
 ## Useful Commands
 
+Preparation commands:
+
 - `git status --short --branch`
 - `git checkout -b codex/release-<version-with-dashes>`
 - `git rev-parse HEAD && git rev-parse origin/main`
 - `git log --oneline <previous-tag>..main`
-- `ruby scripts/release.rb <version> --yes`
 - `swift build`
 - `swift test`
 - `git tag --list`
 - `gh release view <version> --json url,targetCommitish,tagName,name,isDraft,isPrerelease`
+
+Publication commands, only after the release metadata PR is merged and `main` is fast-forwarded:
+
+- `ruby scripts/release.rb <version> --yes` only after inspecting that the script behavior matches the intended release
 - `git tag -a <version> -m "<version>"`
 - `git tag -fa <version> -m "<version>"`
-- `git push origin main`
 - `git push origin <version>`
 - `git push --force origin <version>`
 - `gh release create <version> --title "<version>" --notes-file <path>`

--- a/.codex/skills/release-new-version/SKILL.md
+++ b/.codex/skills/release-new-version/SKILL.md
@@ -1,59 +1,80 @@
 ---
 name: release-new-version
-description: Prepare and publish a new repository release when the user asks to bump a version, update the changelog, create or move a git tag, push release refs, or create or edit a GitHub release. Use for release tasks that must happen from the latest synced `main` branch, with version tags that do not use a `v` prefix.
+description: Prepare and publish a new swift-slack repository release when the user asks to bump a version, adopt or apply CalVer, update release files, update the changelog, create or move a git tag, push release refs, or create or edit a GitHub release. Use for release tasks that must happen through a PR and then from the latest synced `main` branch, with `YYYY.M.PATCH` version tags that do not use a `v` prefix.
 ---
 
 # Release New Version
 
 ## Overview
 
-Use this skill to perform the full release flow safely: update `CHANGELOG.md`, commit the release metadata, ensure the release commit is on the latest `main`, create or move the version tag, push the branch and tag, and create or update the GitHub release page.
+Use this skill to perform the full release flow safely: choose the CalVer version, update release-facing files, update `CHANGELOG.md`, commit release metadata through a PR, ensure the release commit is on the latest `main`, create or move the version tag, push the tag, and create or update the GitHub release page.
 
-Treat `main` as the only valid source for release tags. If a release request starts from another branch, switch to `main`, sync it with `origin/main`, and do the release work there.
+Treat `main` as the only valid source for release tags. Prepare release metadata on a branch and PR when files need to change. After the PR is merged, switch to `main`, sync it with `origin/main`, and publish the tag/release from that merged commit.
+
+## Versioning
+
+- Use calendar versioning in the form `YYYY.M.PATCH`, for example `2026.7.0`.
+- Use the calendar date in the release timezone/current environment to choose `YYYY` and `M`.
+- Do not zero-pad the month. `2026.7.0` is valid; `2026.07.0` is not.
+- Treat `PATCH` as the release counter within the month, not as a SemVer compatibility signal.
+- Use `PATCH = 0` for the first release in a month. Increment it for additional releases in the same month.
+- Reset `PATCH` to `0` when the month changes.
+- Never prepend `v` to tags.
+- Call out breaking changes explicitly in `CHANGELOG.md`; the version number does not encode source compatibility.
 
 ## Inputs
 
-- Release version, for example `0.5.0`
+- Release version, for example `2026.7.0`; if omitted, infer the next `YYYY.M.PATCH` from the current date and existing tags
 - Repository checkout with git and `gh` configured
 - Release notes source, usually `CHANGELOG.md`
 
 ## Workflow
 
-1. Verify repository state.
+1. Verify repository state and choose a release branch.
    - Run `git status --short --branch`.
-   - Confirm the local branch is `main`.
-   - Confirm `HEAD` matches `origin/main`. If it does not, update `main` first before changing release metadata.
+   - Confirm the local base branch matches `origin/main`. If it does not, update from `origin/main` before changing release metadata.
+   - Create or switch to a release preparation branch such as `codex/release-2026-7-0` unless the user explicitly asks only for local edits.
 2. Inspect release context.
    - Read the current `CHANGELOG.md`.
    - Inspect commits since the previous tag or release version so the changelog entry matches the actual release scope.
    - Check whether the target tag already exists locally or remotely.
    - Check whether a GitHub release for that tag already exists.
-3. Update the changelog before tagging.
+3. Update release-facing files before tagging.
    - Convert the unreleased section into a dated release section, or add a new release section if the changelog format differs.
    - Keep the version string exact and never prepend `v`.
    - Keep the changelog aligned with the commits that will actually be on the tagged `main` commit.
+   - Update README package dependency examples to the new release version.
+   - Keep `AGENTS.md` and this skill aligned with the CalVer policy if the policy changes.
+   - Keep `scripts/release.rb` validating `YYYY.M.PATCH` and suggesting the next monthly release counter.
 4. Verify only when needed.
    - If the release changes code, generated artifacts, dependencies, or anything beyond release metadata, run `swift build` and then `swift test`.
    - Keep that order so build failures surface before the slower test pass.
    - If the change is changelog-only or release-metadata-only, verification can be skipped and that should be stated explicitly.
-5. Commit the release metadata on `main`.
+5. Commit the release metadata on the release preparation branch.
    - Create a dedicated commit such as `Prepare <version> release`.
-   - Push `main` to `origin` before finalizing the tag so the tagged commit exists on the remote default branch.
-6. Create or correct the tag.
+   - Push the branch and open a PR. Do not push directly to `main`.
+6. After the PR merges, publish from `main`.
+   - Switch to `main`.
+   - Fetch and fast-forward to `origin/main`.
+   - Confirm the release metadata commit is present on `main`.
+   - Push `main` only when required by the release flow and permitted by branch protection; otherwise rely on the merged PR.
+7. Create or correct the tag.
    - Create an annotated tag named exactly `<version>`.
    - Never use a `v` prefix.
    - If the tag already exists on the wrong commit, move it only after the correct `main` commit exists, then force-push the tag update.
-7. Publish or correct the GitHub release.
+8. Publish or correct the GitHub release.
    - If no release exists, create it from the tag with notes sourced from the new changelog section.
    - If a release already exists, edit it so the notes and tag reference stay aligned with the corrected tag.
-8. Re-check final state.
+9. Re-check final state.
    - Confirm `HEAD`, `origin/main`, and `<version>^{}` resolve to the same commit.
    - Confirm the GitHub release URL and whether it is a draft or prerelease.
 
 ## Guardrails
 
-- Do not release from feature branches, topic branches, or detached HEAD states.
+- Do not publish release tags from feature branches, topic branches, or detached HEAD states.
+- Do not push release metadata directly to `main`; use a branch and PR.
 - Do not tag before the changelog update is committed.
+- Do not use SemVer-style versions such as `0.12.0` for new releases.
 - Do not assume an existing release tag is correct; inspect it.
 - Prefer editing an existing GitHub release instead of creating duplicates.
 - If branch protection messages appear during push, report them, but continue only if the push actually succeeds.
@@ -61,8 +82,10 @@ Treat `main` as the only valid source for release tags. If a release request sta
 ## Useful Commands
 
 - `git status --short --branch`
+- `git checkout -b codex/release-<version-with-dashes>`
 - `git rev-parse HEAD && git rev-parse origin/main`
 - `git log --oneline <previous-tag>..main`
+- `ruby scripts/release.rb <version> --yes`
 - `swift build`
 - `swift test`
 - `git tag --list`

--- a/.codex/skills/release-new-version/agents/openai.yaml
+++ b/.codex/skills/release-new-version/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Release New Version"
-  short_description: "Tag and publish a GitHub release"
-  default_prompt: "Use $release-new-version to prepare the changelog, tag from main, and publish the GitHub release."
+  short_description: "Prepare CalVer releases through PRs"
+  default_prompt: "Use $release-new-version to prepare a CalVer changelog update, PR branch, tag, and GitHub release."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,10 @@ Shared guidance for coding agents working in this repository.
 ## Repository Conventions
 
 - Make git commits for each meaningful change.
-- Create release tags without a `v` prefix (for example `0.0.4`).
+- Use calendar versioning for releases in the form `YYYY.M.PATCH` (for example `2026.7.0`).
+- Treat `PATCH` as the release counter within the month, not as a SemVer compatibility signal.
+- Reset `PATCH` to `0` for the first release in each month, then increment it for additional releases in that month.
+- Create release tags without a `v` prefix (for example `2026.7.0`).
 - Do not use `swift-actions/setup-swift@v2` in GitHub Actions.
 - Run `swift build` or `swift test` when verification is needed.
 - Do not push directly to `main`; use branches and PRs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,28 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project uses calendar versioning in the form `YYYY.M.PATCH`.
+The `PATCH` segment is a release counter within the month, not a SemVer compatibility signal.
 
 ## Unreleased
+
+## [2026.7.0] - 2026-07-02
+
+### Added
+
+* Updated Slack API schemas with newly generated Web API operations and shared model coverage.
+
+### Changed
+
+* Adopted calendar versioning in the form `YYYY.M.PATCH`, starting with this release.
+* Updated README package-version examples for the `2026.7.0` release.
+* Updated the Ruby toolchain reference to `4.0.5`.
+* Updated GitHub Actions Swiftly setup and refreshed the apt index before Swiftly installation.
+
+### Fixed
+
+* Fixed Web API trait template generation and indentation.
+* Removed stale generated schema output from the generation pipeline.
 
 ## [0.11.0] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use the package directly:
 dependencies: [
     .package(
         url: "https://github.com/ainame/swift-slack.git",
-        from: "0.11.0"
+        from: "2026.7.0"
     )
 ]
 ```
@@ -44,7 +44,7 @@ For smaller builds, enable only the traits your app needs:
 ```swift
     .package(
         url: "https://github.com/ainame/swift-slack.git",
-        from: "0.11.0",
+        from: "2026.7.0",
         traits: [
             "SocketMode",   // WebSocket support
             "Events",       // Events API
@@ -151,7 +151,7 @@ The built-in Hummingbird integration is opt-in, so enable the `HummingbirdHTTPAd
 dependencies: [
     .package(
         url: "https://github.com/ainame/swift-slack.git",
-        from: "0.11.0",
+        from: "2026.7.0",
         traits: [
             "Events",
             "HummingbirdHTTPAdapter",

--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'json'
+require 'date'
 require 'time'
 
 def main
@@ -18,10 +19,8 @@ def main
     exit unless STDIN.gets.to_s.strip.downcase == 'y'
   end
 
-  # Test and build
-  puts "Running tests..."
-  system('swift test') or abort "Tests failed"
   system('swift build') or abort "Build failed"
+  system('swift test') or abort "Tests failed"
 
   # Create tag and release
   system("git tag -a #{new_tag} -m 'Release #{new_tag}'")
@@ -53,13 +52,33 @@ def get_version(version = nil)
   puts "Latest tag: #{latest_tag.empty? ? 'none' : latest_tag}"
 
   if version.nil?
-    print "New version (e.g., 0.1.0): "
+    print "New version (e.g., #{suggest_next_calver}): "
     version = STDIN.gets.to_s.strip
   end
-  
-  abort "Invalid version format" unless version =~ /^\d+\.\d+\.\d+$/
+
+  unless valid_calver?(version)
+    abort "Invalid version format. Use YYYY.M.PATCH, for example #{suggest_next_calver}"
+  end
 
   [version, latest_tag]
+end
+
+def valid_calver?(version)
+  version =~ /^\d{4}\.([1-9]|1[0-2])\.\d+$/
+end
+
+def suggest_next_calver(today = Date.today)
+  year = today.year
+  month = today.month
+  prefix = "#{year}.#{month}."
+  patches = `git tag --list '#{prefix}*'`
+    .lines
+    .map(&:strip)
+    .map { |tag| tag[/^#{Regexp.escape(prefix)}(\d+)$/, 1] }
+    .compact
+    .map(&:to_i)
+
+  "#{prefix}#{patches.empty? ? 0 : patches.max + 1}"
 end
 
 # Generate changelog


### PR DESCRIPTION
## Summary
- adopt CalVer release guidance in AGENTS.md and changelog text
- prepare the 2026.7.0 changelog section and README dependency examples
- update the release skill and script to use YYYY.M.PATCH versions

## Verification
- ruby -c scripts/release.rb
- ruby release helper probe for 2026.7.0 / 2026.07.0 / July 2026 suggestion
- python3 skill quick_validate.py .codex/skills/release-new-version
- git diff --check

Swift build/test not run; this is release metadata, documentation, and release-script guidance only.