### PR TITLE
Prepare 2026.7.0 release notes

### DIFF
--- a/.codex/skills/release-new-version/SKILL.md
+++ b/.codex/skills/release-new-version/SKILL.md
@@ -48,9 +48,9 @@ Use two phases. Stop after Phase A unless the release metadata PR has already be
    - Convert the unreleased section into a dated release section, or add a new release section if the changelog format differs.
    - Keep the version string exact and never prepend `v`.
    - Keep the changelog aligned with the commits expected to be on the tagged `main` commit.
-   - Include the PR number and GitHub PR link in every `CHANGELOG.md` release-note bullet, using the format `- [#123](https://github.com/owner/repo/pull/123)`.
-   - If one changelog bullet summarizes multiple PRs, include a linked PR reference for each PR covered by that bullet.
-   - Do not leave bare PR numbers such as `#123` in newly written changelog entries.
+   - Include the PR number in every `CHANGELOG.md` release-note bullet using GitHub-native references such as `- #123`.
+   - If one changelog bullet summarizes multiple PRs, include a `#123`-style reference for each PR covered by that bullet.
+   - Prefer bare `#123` references over full Markdown links for same-repository PRs.
    - Update README package dependency examples to the new release version.
    - Keep `AGENTS.md` and this skill aligned with the CalVer policy if the policy changes.
    - Keep `scripts/release.rb` validating `YYYY.M.PATCH` and suggesting the next monthly release counter.

--- a/.codex/skills/release-new-version/SKILL.md
+++ b/.codex/skills/release-new-version/SKILL.md
@@ -41,12 +41,16 @@ Use two phases. Stop after Phase A unless the release metadata PR has already be
 2. Inspect release context.
    - Read the current `CHANGELOG.md`.
    - Inspect commits since the previous tag or release version so the changelog entry matches the actual release scope.
+   - Inspect merged PRs since the previous tag with their numbers and URLs, for example with `gh pr list --state merged --search "merged:>=<date>" --json number,title,url,mergedAt`.
    - Check whether the target tag already exists locally or remotely.
    - Check whether a GitHub release for that tag already exists.
 3. Update release-facing files.
    - Convert the unreleased section into a dated release section, or add a new release section if the changelog format differs.
    - Keep the version string exact and never prepend `v`.
    - Keep the changelog aligned with the commits expected to be on the tagged `main` commit.
+   - Include the PR number and GitHub PR link in every `CHANGELOG.md` release-note bullet, using the format `- [#123](https://github.com/owner/repo/pull/123)`.
+   - If one changelog bullet summarizes multiple PRs, include a linked PR reference for each PR covered by that bullet.
+   - Do not leave bare PR numbers such as `#123` in newly written changelog entries.
    - Update README package dependency examples to the new release version.
    - Keep `AGENTS.md` and this skill aligned with the CalVer policy if the policy changes.
    - Keep `scripts/release.rb` validating `YYYY.M.PATCH` and suggesting the next monthly release counter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,22 @@ The `PATCH` segment is a release counter within the month, not a SemVer compatib
 
 ### Added
 
-* Updated Slack API schemas with newly generated Web API operations and shared model coverage.
+* Updated Slack API schemas with newly generated Web API operations and shared model coverage - [#112](https://github.com/ainame/swift-slack/pull/112), [#113](https://github.com/ainame/swift-slack/pull/113), [#115](https://github.com/ainame/swift-slack/pull/115), [#118](https://github.com/ainame/swift-slack/pull/118)
 
 ### Changed
 
-* Adopted calendar versioning in the form `YYYY.M.PATCH`, starting with this release.
-* Updated README package-version examples for the `2026.7.0` release.
-* Updated the Ruby toolchain reference to `4.0.5`.
-* Tightened the release workflow guidance to keep tag and GitHub release publication on merged `main` commits.
-* Updated GitHub Actions checkout and cache actions.
-* Updated GitHub Actions Swiftly setup and refreshed the apt index before Swiftly installation.
+* Adopted calendar versioning in the form `YYYY.M.PATCH`, starting with this release - [#119](https://github.com/ainame/swift-slack/pull/119)
+* Updated README package-version examples for the `2026.7.0` release - [#119](https://github.com/ainame/swift-slack/pull/119)
+* Updated the Ruby toolchain reference to `4.0.5` - [#111](https://github.com/ainame/swift-slack/pull/111)
+* Tightened the release workflow guidance to keep tag and GitHub release publication on merged `main` commits and require linked PR references in changelog entries - [#119](https://github.com/ainame/swift-slack/pull/119), [#120](https://github.com/ainame/swift-slack/pull/120)
+* Updated GitHub Actions checkout and cache actions - [#114](https://github.com/ainame/swift-slack/pull/114), [#116](https://github.com/ainame/swift-slack/pull/116)
+* Updated GitHub Actions Swiftly setup and refreshed the apt index before Swiftly installation - [#118](https://github.com/ainame/swift-slack/pull/118)
 
 ### Fixed
 
-* Fixed generated channel priority property typing.
-* Fixed Web API trait template generation and indentation.
-* Removed stale generated schema output from the generation pipeline.
+* Fixed generated channel priority property typing - [#117](https://github.com/ainame/swift-slack/pull/117)
+* Fixed Web API trait template generation and indentation - [#118](https://github.com/ainame/swift-slack/pull/118)
+* Removed stale generated schema output from the generation pipeline - [#118](https://github.com/ainame/swift-slack/pull/118)
 
 ## [0.11.0] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,22 @@ The `PATCH` segment is a release counter within the month, not a SemVer compatib
 
 ### Added
 
-* Updated Slack API schemas with newly generated Web API operations and shared model coverage - [#112](https://github.com/ainame/swift-slack/pull/112), [#113](https://github.com/ainame/swift-slack/pull/113), [#115](https://github.com/ainame/swift-slack/pull/115), [#118](https://github.com/ainame/swift-slack/pull/118)
+* Updated Slack API schemas with newly generated Web API operations and shared model coverage - #112, #113, #115, #118
 
 ### Changed
 
-* Adopted calendar versioning in the form `YYYY.M.PATCH`, starting with this release - [#119](https://github.com/ainame/swift-slack/pull/119)
-* Updated README package-version examples for the `2026.7.0` release - [#119](https://github.com/ainame/swift-slack/pull/119)
-* Updated the Ruby toolchain reference to `4.0.5` - [#111](https://github.com/ainame/swift-slack/pull/111)
-* Tightened the release workflow guidance to keep tag and GitHub release publication on merged `main` commits and require linked PR references in changelog entries - [#119](https://github.com/ainame/swift-slack/pull/119), [#120](https://github.com/ainame/swift-slack/pull/120)
-* Updated GitHub Actions checkout and cache actions - [#114](https://github.com/ainame/swift-slack/pull/114), [#116](https://github.com/ainame/swift-slack/pull/116)
-* Updated GitHub Actions Swiftly setup and refreshed the apt index before Swiftly installation - [#118](https://github.com/ainame/swift-slack/pull/118)
+* Adopted calendar versioning in the form `YYYY.M.PATCH`, starting with this release - #119
+* Updated README package-version examples for the `2026.7.0` release - #119
+* Updated the Ruby toolchain reference to `4.0.5` - #111
+* Tightened the release workflow guidance to keep tag and GitHub release publication on merged `main` commits and prefer GitHub-native PR references in changelog entries - #119, #120
+* Updated GitHub Actions checkout and cache actions - #114, #116
+* Updated GitHub Actions Swiftly setup and refreshed the apt index before Swiftly installation - #118
 
 ### Fixed
 
-* Fixed generated channel priority property typing - [#117](https://github.com/ainame/swift-slack/pull/117)
-* Fixed Web API trait template generation and indentation - [#118](https://github.com/ainame/swift-slack/pull/118)
-* Removed stale generated schema output from the generation pipeline - [#118](https://github.com/ainame/swift-slack/pull/118)
+* Fixed generated channel priority property typing - #117
+* Fixed Web API trait template generation and indentation - #118
+* Removed stale generated schema output from the generation pipeline - #118
 
 ## [0.11.0] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ The `PATCH` segment is a release counter within the month, not a SemVer compatib
 * Adopted calendar versioning in the form `YYYY.M.PATCH`, starting with this release.
 * Updated README package-version examples for the `2026.7.0` release.
 * Updated the Ruby toolchain reference to `4.0.5`.
+* Tightened the release workflow guidance to keep tag and GitHub release publication on merged `main` commits.
+* Updated GitHub Actions checkout and cache actions.
 * Updated GitHub Actions Swiftly setup and refreshed the apt index before Swiftly installation.
 
 ### Fixed
 
+* Fixed generated channel priority property typing.
 * Fixed Web API trait template generation and indentation.
 * Removed stale generated schema output from the generation pipeline.
 


### PR DESCRIPTION
## Summary
- Update the 2026.7.0 changelog entry for commits that landed after the initial release prep
- Keep README package examples on 2026.7.0

## Verification
- Not run; changelog-only release metadata update